### PR TITLE
C23: swap ANSI for remaining K&R-style declarations

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -12,8 +12,7 @@ static aligned realspace[SPACE / ALIGNMENT];
 #define space ((char *) realspace)
 static unsigned int avail = SPACE; /* multiple of ALIGNMENT; 0<=avail<=SPACE */
 
-/*@null@*//*@out@*/char *alloc(n)
-unsigned int n;
+/*@null@*//*@out@*/char *alloc(unsigned int n)
 {
   char *x;
   n = ALIGNMENT + n - (n & (ALIGNMENT - 1)); /* XXX: could overflow */
@@ -23,8 +22,7 @@ unsigned int n;
   return x;
 }
 
-void alloc_free(x)
-char *x;
+void alloc_free(char *x)
 {
   if (x >= space)
     if (x < space + SPACE)

--- a/src/alloc_re.c
+++ b/src/alloc_re.c
@@ -3,10 +3,7 @@
 #include "alloc.h"
 #include "byte.h"
 
-int alloc_re(x,m,n)
-char **x;
-unsigned int m;
-unsigned int n;
+int alloc_re(char **x,unsigned int m,unsigned int n)
 {
   char *y;
  

--- a/src/buffer_0.c
+++ b/src/buffer_0.c
@@ -2,7 +2,7 @@
 
 #include "buffer.h"
 
-int buffer_0_read(fd,buf,len) int fd; char *buf; int len;
+int buffer_0_read(int fd, char *buf, unsigned int len)
 {
   if (buffer_flush(buffer_1) == -1) return -1;
   return buffer_unixread(fd,buf,len);

--- a/src/byte.h
+++ b/src/byte.h
@@ -3,11 +3,11 @@
 #ifndef BYTE_H
 #define BYTE_H
 
-extern unsigned int byte_chr(char *,register unsigned int,int);
-extern unsigned int byte_rchr(char *,register unsigned int,int);
-extern void byte_copy(register char *,register unsigned int,register char *);
-extern void byte_copyr(register char *,register unsigned int,register char *);
-extern int byte_diff(register char *,register unsigned int,register char *);
+extern unsigned int byte_chr(char *,unsigned int,int);
+extern unsigned int byte_rchr(char *,unsigned int,int);
+extern void byte_copy(char *,unsigned int,char *);
+extern void byte_copyr(char *,unsigned int,char *);
+extern int byte_diff(char *,unsigned int,char *);
 extern void byte_zero(char *,register unsigned int);
 
 #define byte_equal(s,n,t) (!byte_diff((s),(n),(t)))

--- a/src/byte_chr.c
+++ b/src/byte_chr.c
@@ -2,10 +2,7 @@
 
 #include "byte.h"
 
-unsigned int byte_chr(s,n,c)
-char *s;
-register unsigned int n;
-int c;
+unsigned int byte_chr(char *s, register unsigned int n, int c)
 {
   register char ch;
   register char *t;

--- a/src/byte_copy.c
+++ b/src/byte_copy.c
@@ -2,10 +2,7 @@
 
 #include "byte.h"
 
-void byte_copy(to,n,from)
-register char *to;
-register unsigned int n;
-register char *from;
+void byte_copy(register char *to,register unsigned int n,register char *from)
 {
   for (;;) {
     if (!n) return; *to++ = *from++; --n;

--- a/src/byte_cr.c
+++ b/src/byte_cr.c
@@ -2,10 +2,7 @@
 
 #include "byte.h"
 
-void byte_copyr(to,n,from)
-register char *to;
-register unsigned int n;
-register char *from;
+void byte_copyr(register char *to,register unsigned int n,register char *from)
 {
   to += n;
   from += n;

--- a/src/byte_diff.c
+++ b/src/byte_diff.c
@@ -2,10 +2,7 @@
 
 #include "byte.h"
 
-int byte_diff(s,n,t)
-register char *s;
-register unsigned int n;
-register char *t;
+int byte_diff(register char *s,register unsigned int n,register char *t)
 {
   for (;;) {
     if (!n) return 0; if (*s != *t) break; ++s; ++t; --n;

--- a/src/byte_rchr.c
+++ b/src/byte_rchr.c
@@ -2,10 +2,7 @@
 
 #include "byte.h"
 
-unsigned int byte_rchr(s,n,c)
-char *s;
-register unsigned int n;
-int c;
+unsigned int byte_rchr(char *s,register unsigned int n,int c)
 {
   register char ch;
   register char *t;

--- a/src/select.h2
+++ b/src/select.h2
@@ -8,6 +8,5 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/select.h>
-extern int select(int,fd_set *,fd_set *,fd_set *,struct timeval *);
 
 #endif

--- a/src/wait.h
+++ b/src/wait.h
@@ -5,8 +5,6 @@
 
 extern int wait_pid(int *,int);
 extern int wait_nohang(int *);
-extern int wait_stop();
-extern int wait_stopnohang();
 
 #define wait_crashed(w) ((w) & 127)
 #define wait_exitcode(w) ((w) >> 8)

--- a/src/wait_nohang.c
+++ b/src/wait_nohang.c
@@ -4,7 +4,7 @@
 #include <sys/wait.h>
 #include "haswaitp.h"
 
-int wait_nohang(wstat) int *wstat;
+int wait_nohang(int *wstat)
 {
 #ifdef HASWAITPID
   return waitpid(-1,wstat,WNOHANG);

--- a/src/wait_pid.c
+++ b/src/wait_pid.c
@@ -7,7 +7,7 @@
 
 #ifdef HASWAITPID
 
-int wait_pid(wstat,pid) int *wstat; int pid;
+int wait_pid(int *wstat, int pid)
 {
   int r;
 
@@ -24,7 +24,7 @@ int wait_pid(wstat,pid) int *wstat; int pid;
 static int oldpid = 0;
 static int oldwstat; /* defined if(oldpid) */
 
-int wait_pid(wstat,pid) int *wstat; int pid;
+int wait_pid(int *wstat, int pid)
 {
   int r;
 


### PR DESCRIPTION
Hi,

Most of the function declarations in runit are ANSI-style but there are a few remaining K&R-style definitions that prevent the runit source from compiling as C23 code, which is the default assumption of gcc-15.

I have a prepared a patch that swaps the remaining K&R-style definitions with full ANSI-style prototypes. Would you consider including this patch or something like it, if you haven't already got a solution in the works for this?

I *think* the assumptions in this patch are compatible with BSD and likely other build targets but apologies if I have missed anything as I only tested this on Debian sid.

Thanks!