### PR TITLE
Fix build with gcc15

### DIFF
--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,3 +1,9 @@
+  * alloc.h, buffer.c, buffer.h, buffer_get.c, buffer_put.c, buffer_write.c,
+    byte.h, pathexec_env.c, runit.c, runsv.c, runsvdir.c, select.h1,
+    select.h2, sig.c, sig.h, sig_catch.c, svlogd.c, svlogd.dist, wait.h:
+    fix build with gcc15: in C23 f() means f(void), consequently signal
+    handler functions now are f(int), alloc_free() parameter needs cast,
+    buffer_unixwrite() removes "const" from parameter.
   * utmpset.c: check length of line argument to match struct utmp; properly
     handle line argument with max length (thx github/Skyb0rg007).
   * doc/index.html: add reference to repository on github.com.

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -3,8 +3,8 @@
 #ifndef ALLOC_H
 #define ALLOC_H
 
-extern /*@null@*//*@out@*/char *alloc();
-extern void alloc_free();
-extern int alloc_re();
+extern /*@null@*//*@out@*/char *alloc(unsigned int);
+extern void alloc_free(char *);
+extern int alloc_re(char **,unsigned int,unsigned int);
 
 #endif

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2,7 +2,7 @@
 
 #include "buffer.h"
 
-void buffer_init(buffer *s,int (*op)(),int fd,char *buf,unsigned int len)
+void buffer_init(buffer *s,int (*op)(int,char *,unsigned int),int fd,char *buf,unsigned int len)
 {
   s->x = buf;
   s->fd = fd;

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -8,14 +8,14 @@ typedef struct buffer {
   unsigned int p;
   unsigned int n;
   int fd;
-  int (*op)();
+  int (*op)(int,char *,unsigned int);
 } buffer;
 
 #define BUFFER_INIT(op,fd,buf,len) { (buf), 0, (len), (fd), (op) }
 #define BUFFER_INSIZE 8192
 #define BUFFER_OUTSIZE 8192
 
-extern void buffer_init(buffer *,int (*)(),int,char *,unsigned int);
+extern void buffer_init(buffer *,int (*)(int,char *,unsigned int),int,char *,unsigned int);
 
 extern int buffer_flush(buffer *);
 extern int buffer_put(buffer *,const char *,unsigned int);
@@ -50,7 +50,7 @@ extern void buffer_seek(buffer *,unsigned int);
 extern int buffer_copy(buffer *,buffer *);
 
 extern int buffer_unixread(int,char *,unsigned int);
-extern int buffer_unixwrite(int,const char *,unsigned int);
+extern int buffer_unixwrite(int,char *,unsigned int);
 
 extern buffer *buffer_0;
 extern buffer *buffer_0small;

--- a/src/buffer_get.c
+++ b/src/buffer_get.c
@@ -4,7 +4,7 @@
 #include "byte.h"
 #include "error.h"
 
-static int oneread(int (*op)(),int fd,char *buf,unsigned int len)
+static int oneread(int (*op)(int,char *,unsigned int),int fd,char *buf,unsigned int len)
 {
   int r;
 

--- a/src/buffer_put.c
+++ b/src/buffer_put.c
@@ -5,7 +5,7 @@
 #include "byte.h"
 #include "error.h"
 
-static int allwrite(int (*op)(),int fd,const char *buf,unsigned int len)
+static int allwrite(int (*op)(int,char *,unsigned int),int fd,const char *buf,unsigned int len)
 {
   int w;
 

--- a/src/buffer_write.c
+++ b/src/buffer_write.c
@@ -3,7 +3,7 @@
 #include <unistd.h>
 #include "buffer.h"
 
-int buffer_unixwrite(int fd,const char *buf,unsigned int len)
+int buffer_unixwrite(int fd,char *buf,unsigned int len)
 {
   return write(fd,buf,len);
 }

--- a/src/byte.h
+++ b/src/byte.h
@@ -3,12 +3,12 @@
 #ifndef BYTE_H
 #define BYTE_H
 
-extern unsigned int byte_chr();
-extern unsigned int byte_rchr();
-extern void byte_copy();
-extern void byte_copyr();
-extern int byte_diff();
-extern void byte_zero();
+extern unsigned int byte_chr(char *,register unsigned int,int);
+extern unsigned int byte_rchr(char *,register unsigned int,int);
+extern void byte_copy(register char *,register unsigned int,register char *);
+extern void byte_copyr(register char *,register unsigned int,register char *);
+extern int byte_diff(register char *,register unsigned int,register char *);
+extern void byte_zero(char *,register unsigned int);
 
 #define byte_equal(s,n,t) (!byte_diff((s),(n),(t)))
 

--- a/src/pathexec_env.c
+++ b/src/pathexec_env.c
@@ -65,7 +65,7 @@ void pathexec_env_run(const char *file, char *const *argv)
   e[elen] = 0;
 
   pathexec_run(file,argv,e);
-  alloc_free(e);
+  alloc_free((char *)e);
 }
 
 void pathexec(char *const *argv)

--- a/src/runit.c
+++ b/src/runit.c
@@ -31,15 +31,15 @@ int selfpipe[2];
 int sigc =0;
 int sigi =0;
 
-void sig_cont_handler (void) {
+void sig_cont_handler (int unused) {
   sigc++;
   write(selfpipe[1], "", 1);
 }
-void sig_int_handler (void) {
+void sig_int_handler (int unused) {
   sigi++;
   write(selfpipe[1], "", 1);
 }
-void sig_child_handler (void) { write(selfpipe[1], "", 1); }
+void sig_child_handler (int unused) { write(selfpipe[1], "", 1); }
 
 void sync_if_needed() {
   struct stat s;

--- a/src/runsv.c
+++ b/src/runsv.c
@@ -83,8 +83,8 @@ void warnx(char *m1, char *m2, char *m3) {
 
 void stopservice(struct svdir *);
 
-void s_child() { write(selfpipe[1], "", 1); }
-void s_term() {
+void s_child(int unused) { write(selfpipe[1], "", 1); }
+void s_term(int unused) {
   sigterm =1;
   write(selfpipe[1], "", 1); /* XXX */
 }

--- a/src/runsvdir.c
+++ b/src/runsvdir.c
@@ -51,8 +51,8 @@ void warn(char *m1, char *m2) {
 void warn3x(char *m1, char *m2, char *m3) {
   strerr_warn6("runsvdir ", svdir, ": warning: ", m1, m2, m3, 0);
 } 
-void s_term() { exitsoon =1; }
-void s_hangup() { exitsoon =2; }
+void s_term(int unused) { exitsoon =1; }
+void s_hangup(int unused) { exitsoon =2; }
 
 void runsv(int no, char *name) {
   int pid;

--- a/src/select.h1
+++ b/src/select.h1
@@ -7,6 +7,6 @@
 
 #include <sys/types.h>
 #include <sys/time.h>
-extern int select();
+extern int select(int,fd_set *,fd_set *,fd_set *,struct timeval *);
 
 #endif

--- a/src/select.h2
+++ b/src/select.h2
@@ -8,6 +8,6 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/select.h>
-extern int select();
+extern int select(int,fd_set *,fd_set *,fd_set *,struct timeval *);
 
 #endif

--- a/src/sig.c
+++ b/src/sig.c
@@ -11,5 +11,5 @@ int sig_int = SIGINT;
 int sig_pipe = SIGPIPE;
 int sig_term = SIGTERM;
 
-void (*sig_defaulthandler)() = SIG_DFL;
-void (*sig_ignorehandler)() = SIG_IGN;
+void (*sig_defaulthandler)(int) = SIG_DFL;
+void (*sig_ignorehandler)(int) = SIG_IGN;

--- a/src/sig.h
+++ b/src/sig.h
@@ -11,10 +11,10 @@ extern int sig_int;
 extern int sig_pipe;
 extern int sig_term;
 
-extern void (*sig_defaulthandler)();
-extern void (*sig_ignorehandler)();
+extern void (*sig_defaulthandler)(int);
+extern void (*sig_ignorehandler)(int);
 
-extern void sig_catch(int,void (*)());
+extern void sig_catch(int,void (*)(int));
 #define sig_ignore(s) (sig_catch((s),sig_ignorehandler))
 #define sig_uncatch(s) (sig_catch((s),sig_defaulthandler))
 

--- a/src/sig_catch.c
+++ b/src/sig_catch.c
@@ -4,7 +4,7 @@
 #include "sig.h"
 #include "hassgact.h"
 
-void sig_catch(int sig,void (*f)())
+void sig_catch(int sig,void (*f)(int))
 {
 #ifdef HASSIGACTION
   struct sigaction sa;

--- a/src/svlogd.c
+++ b/src/svlogd.c
@@ -616,11 +616,11 @@ int buffer_pread(int fd, char *s, unsigned int len) {
   if (i > 0) linecomplete =(s[i -1] == '\n');
   return(i);
 }
-void sig_term_handler(void) {
+void sig_term_handler(int unused) {
   if (verbose) strerr_warn2(INFO, "sigterm received.", 0);
   exitasap =1;
 }
-void sig_child_handler(void) {
+void sig_child_handler(int unused) {
   int pid, l;
 
   if (verbose) strerr_warn2(INFO, "sigchild received.", 0);
@@ -632,11 +632,11 @@ void sig_child_handler(void) {
         break;
       }
 }
-void sig_alarm_handler(void) {
+void sig_alarm_handler(int unused) {
   if (verbose) strerr_warn2(INFO, "sigalarm received.", 0);
   rotateasap =1;
 }
-void sig_hangup_handler(void) {
+void sig_hangup_handler(int unused) {
   if (verbose) strerr_warn2(INFO, "sighangup received.", 0);
   reopenasap =1;
 }

--- a/src/svlogd.dist
+++ b/src/svlogd.dist
@@ -1,7 +1,7 @@
 usage: svlogd [-ttv] [-r c] [-R abc] [-l len] [-b buflen] dir ...
 
 111
-$Id: 66d40067fb843ee6cde160e47c9dee5c73986f6d $
+$Id: 1c7d44dcb693d438d44c44f94b5242960a9063ed $
 usage: svlogd [-ttv] [-r c] [-R abc] [-l len] [-b buflen] dir ...
 
 111

--- a/src/wait.h
+++ b/src/wait.h
@@ -3,8 +3,8 @@
 #ifndef WAIT_H
 #define WAIT_H
 
-extern int wait_pid();
-extern int wait_nohang();
+extern int wait_pid(int *,int);
+extern int wait_nohang(int *);
 extern int wait_stop();
 extern int wait_stopnohang();
 


### PR DESCRIPTION
In C23 f() means f(void), consequently signal handler functions now are f(int), alloc_free() parameter needs cast, buffer_unixwrite() removes "const" from parameter.

https://gcc.gnu.org/gcc-15/changes.html