### PR TITLE
* runit.c: really restart stage 2 if it crashed

### DIFF
--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,3 +1,4 @@
+  * runit.c: really restart stage 2 if it crashed.
   * alloc.c, alloc_re.c, buffer_0.c, byte.h, byte_chr.c, byte_copy.c,
     byte_cr.c, byte_diff.c, byte_rchr.c, select.h2, wait.h, wait_nohang.c,
     wait_pid.c: C23: swap ANSI for remaining K&R-style declarations

--- a/src/runit.c
+++ b/src/runit.c
@@ -177,7 +177,7 @@ int main (int argc, const char * const *argv, char * const *envp) {
       }
 
       if (child == pid) {
-        if (wait_exitcode(wstat) != 0) {
+        if (wait_crashed(wstat) || wait_exitcode(wstat) != 0) {
           if (wait_crashed(wstat))
             strerr_warn3(WARNING, "child crashed: ", stage[st], 0);
           else


### PR DESCRIPTION
The runit man page states in section Stage 2: "if it crashes, or exits 111, it will be restarted", which was true only for exit code 111. Now it's also restarted when killed by uncought signal.