### PR TITLE
runsvchdir: get working directory from env

### DIFF
--- a/doc/runsvchdir.8.html
+++ b/doc/runsvchdir.8.html
@@ -16,26 +16,33 @@ runsvchdir - change services directory of <i>runsvdir(8)</i>
 <i>dir</i> 
 <h2><a name='sect2'>Description</a></h2>
 <i>dir</i> is a services directory for the use with <i><b>runsvdir</b>(8)</i>.
-If <i>dir</i> does not start with a slash, it is searched in /etc/runit/runsvdir/.
+If <i>dir</i> does not start with a slash, it is searched in <b>runsvchdir</b>&rsquo;s
+working directory, by default <i>/etc/runit/runsvdir/</i>.
 <i>dir</i> must not start with a dot. <p>
-<b>runsvchdir</b> switches to the directory <i>/etc/runit/runsvdir/</i>,
+<b>runsvchdir</b> switches to its working directory,
 copies <i>current</i> to <i>previous</i>, and replaces <i>current</i> with a symlink pointing
 to <i>dir</i>. <p>
 Normally  <i>/service</i> is a symlink to <i>current</i>, and <i><b>runsvdir</b>(8)</i> is running
 <i>/service/</i>. 
-<h2><a name='sect3'>Exit Codes</a></h2>
+<h2><a name='sect3'>Environment</a></h2>
+<dl>
+
+<dt><b>RUNSVDIR</b> </dt>
+<dd>The environment variable
+$RUNSVDIR overrides the default working directory <i>/etc/runit/runsvdir/</i>. </dd>
+<h2><a name='sect4'>Exit Codes</a></h2>
 <b>runsvchdir</b> prints an error message and exits 111 on
 error. <b>runsvchdir</b> exits 0 on success. 
-<h2><a name='sect4'>Files</a></h2>
+<h2><a name='sect5'>Files</a></h2>
  /etc/runit/runsvdir/previous<br>
   /etc/runit/runsvdir/current<br>
   /etc/runit/runsvdir/current.new<br>
  
-<h2><a name='sect5'>See Also</a></h2>
+<h2><a name='sect6'>See Also</a></h2>
 <i>runsvdir(8)</i>, <i>runit(8)</i>, <i>runit-init(8)</i>, <i>sv(8)</i>, <i>runsv(8)</i> <p>
 <i>https://smarden.org/runit/</i>
 
-<h2><a name='sect6'>Author</a></h2>
+<h2><a name='sect7'>Author</a></h2>
 Gerrit Pape &lt;pape@smarden.org&gt; <p>
 
 <hr><p>
@@ -44,10 +51,11 @@ Gerrit Pape &lt;pape@smarden.org&gt; <p>
 <li><a name='toc0' href='#sect0'>Name</a></li>
 <li><a name='toc1' href='#sect1'>Synopsis</a></li>
 <li><a name='toc2' href='#sect2'>Description</a></li>
-<li><a name='toc3' href='#sect3'>Exit Codes</a></li>
-<li><a name='toc4' href='#sect4'>Files</a></li>
-<li><a name='toc5' href='#sect5'>See Also</a></li>
-<li><a name='toc6' href='#sect6'>Author</a></li>
+<li><a name='toc3' href='#sect3'>Environment</a></li>
+<li><a name='toc4' href='#sect4'>Exit Codes</a></li>
+<li><a name='toc5' href='#sect5'>Files</a></li>
+<li><a name='toc6' href='#sect6'>See Also</a></li>
+<li><a name='toc7' href='#sect7'>Author</a></li>
 </ul>
 </body>
 </html>

--- a/man/runsvchdir.8
+++ b/man/runsvchdir.8
@@ -10,13 +10,15 @@ is a services directory for the use with
 .BR runsvdir (8).
 If
 .I dir
-does not start with a slash, it is searched in /etc/runit/runsvdir/.
+does not start with a slash, it is searched in
+.B runsvchdir 's
+working directory, by default
+.IR /etc/runit/runsvdir/.
 .I dir
 must not start with a dot.
 .P
 .B runsvchdir
-switches to the directory
-.IR /etc/runit/runsvdir/ ,
+switches to its working directory,
 copies
 .I current
 to
@@ -34,6 +36,11 @@ and
 .BR runsvdir (8)
 is running
 .IR /service/ .
+.SH ENVIRONMENT
+.TP
+.B RUNSVDIR
+The environment variable $RUNSVDIR overrides the default working directory
+.IR /etc/runit/runsvdir/ .
 .SH EXIT CODES
 .B runsvchdir
 prints an error message and exits 111 on error.

--- a/src/runsvchdir.c
+++ b/src/runsvchdir.c
@@ -5,13 +5,14 @@
 #include "strerr.h"
 #include "error.h"
 #include "buffer.h"
+#include "env.h"
 
 #define USAGE " dir"
-#define SVDIR "/etc/runit/runsvdir"
 
 #define VERSION "$Id$"
 
 char *progname;
+char *runsvdir ="/etc/runit/runsvdir";
 char *new;
 
 void usage () { strerr_die4x(1, "usage: ", progname, USAGE, "\n"); }
@@ -30,13 +31,15 @@ int main (int argc, char **argv) {
   struct stat s;
   int dev;
   int ino;
+  char *x;
 
   progname =*argv++;
   if (! argv || ! *argv) usage();
 
   new =*argv;
+  if ((x =env_get("RUNSVDIR"))) runsvdir =x;
   if (new[0] == '.') fatalx(new, ": must not start with a dot.");
-  if (chdir(SVDIR) == -1) fatal("unable to chdir: ", SVDIR);
+  if (chdir(runsvdir) == -1) fatal("unable to chdir: ", runsvdir);
 
   if (stat(new, &s) == -1) {
     if (errno == error_noent) fatal(new, 0);


### PR DESCRIPTION
Hello,
The runsvchdir's working directory is hardcoded as /etc/runit/runsvdir/, so runsvchdir can be used only on the system-wide runsvdir instance. However runsvdir can also run nested as a service, for example see
https://christian.amsuess.com/tutorials/nested-runsvdir/
This is especially relevant as some D.E. are recently relying on services started with the user session and an equivalent of 'systemd --user' can be implemented with a nested runsvdir.

This patch makes runsvchdir working directory configurable with a $RUNSVDIR environment variable, roughly the same way as $SVDIR acts on sv.

> $ RUNSVDIR=~/.runit/runsvdir/ runsvchdir default
> runsvchdir: default: current.
> 
> $ RUNSVDIR=~/.runit/runsvdir/ runsvchdir headless
> runsvchdir: headless: now current.
> 
> $ ls -l ~/.runit/runsvdir/current
> lrwxrwxrwx 1 lorenz lorenz 8 Oct 11 12:53 /home/lorenz/.runit/runsvdir/current -> headless

