### PR TITLE
* sv.c: fix regression introduced with 5fe1bc7: rc of sv status in ls…

### DIFF
--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,3 +1,6 @@
+  * sv.c: fix regression introduced with 5fe1bc7: exit code of sv status in
+    "lsb" mode is not 3 in all cases when the service is "down" (thx Fabian
+    Ruff, David Mountney for the patch).
   * alloc.c, alloc_re.c, buffer_0.c, byte.h, byte_chr.c, byte_copy.c,
     byte_cr.c, byte_diff.c, byte_rchr.c, select.h2, wait.h, wait_nohang.c,
     wait_pid.c: C23: swap ANSI for remaining K&R-style declarations

--- a/src/sv.c
+++ b/src/sv.c
@@ -168,7 +168,7 @@ int status(char *unused) {
   }
   else {
     outs("; ");
-    if (svstatus_get()) { rc =svstatus_print("log"); outs("\n"); }
+    if (svstatus_get()) { svstatus_print("log"); outs("\n"); }
   }
   islog =0;
   flush("");

--- a/src/sv.dist
+++ b/src/sv.dist
@@ -1,7 +1,7 @@
 usage: sv [-v] [-w sec] command service ...
 
 100
-$Id: bccdf71babe2596029c67cd0f6cec89bd05844a2 $
+$Id: baa96cd95da0d4daef7818741632c7b5e5d34a05 $
 usage: sv [-v] [-w sec] command service ...
 
 100


### PR DESCRIPTION
…b mode

Starting with 5fe1bc7 the exit code of sv status in "lsb" mode was not 3 in all cases when the service was "down" (thx Fabian Ruff, David Mountney for the patch).

This commit finally applies the patch from David Mountney, see https://skarnet.org/lists/supervision/index.html#msg939