### PR TITLE
* svlogd.c: never prune the in-progress .u (thx Mike Pomraning)

### DIFF
--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,3 +1,5 @@
+  * svlogd.c: never prune the in-progress .u (thx Mike Pomraning for the
+    draft patch).
   * alloc.c, alloc_re.c, buffer_0.c, byte.h, byte_chr.c, byte_copy.c,
     byte_cr.c, byte_diff.c, byte_rchr.c, select.h2, wait.h, wait_nohang.c,
     wait_pid.c: C23: swap ANSI for remaining K&R-style declarations

--- a/src/svlogd.c
+++ b/src/svlogd.c
@@ -235,8 +235,11 @@ void rmoldest(struct logdir *ld) {
           warn2("unable to unlink processor leftover", f->d_name);
       }
       else {
-        ++n;
-        if (str_diff(f->d_name, oldest) < 0) byte_copy(oldest, 27, f->d_name);
+        ++n; /* count .s and .u files ... */
+        if (str_diff(f->d_name, oldest) < 0)
+          /* ... but don't unlink our pending .u if the clock is funny */
+          if ((ld->fnsave[26] != 'u') || str_diff(ld->fnsave, f->d_name))
+            byte_copy(oldest, 27, f->d_name);
       }
       errno =0;
     }

--- a/src/svlogd.dist
+++ b/src/svlogd.dist
@@ -1,7 +1,7 @@
 usage: svlogd [-ttv] [-r c] [-R abc] [-l len] [-b buflen] dir ...
 
 111
-$Id: 1c7d44dcb693d438d44c44f94b5242960a9063ed $
+$Id: 75895b2a099dd6ab02e9bcf480ae86011f9fc234 $
 usage: svlogd [-ttv] [-r c] [-R abc] [-l len] [-b buflen] dir ...
 
 111


### PR DESCRIPTION
"When rotating, svlogd treats unfinished .u files and saved .s files alike, deleting the oldest it finds.

However, if the system clock has stepped backward, the in-progress .u file, which is input for the post-rotation processor, may appear older than any rotated .s files. In that case, svlogd becomes wholly unresponsive, stuck in a pathological loop trying to process a file that doesn't exist, and must be SIGKILLed."

This commit finally applies the patch from Mike Pomraning (slighly adapted), see
https://skarnet.org/lists/supervision/0698.html