### PR TITLE
use CRLF for stage transtition messages on console

### DIFF
--- a/src/strerr_die.c
+++ b/src/strerr_die.c
@@ -22,7 +22,7 @@ void strerr_warn(const char *x1,const char *x2,const char *x3,const char *x4,con
     se = se->who;
   }
  
-  buffer_puts(buffer_2,"\n");
+  buffer_puts(buffer_2,"\r\n");
   buffer_flush(buffer_2);
 }
 


### PR DESCRIPTION
when writing stage transtition messages to the console, using "\n" alone may not reliably move the cursor to column 0 depending on the terminal or console state

runit writes directly to console, so post-processing may not be enabled explicitly emitting "\r\n" ensures cursor is in column 0 of terminal after this change the messages gonna be like this : 
```
- runit: leave stage: /etc/runit/1
- runit: leave stage: /etc/runit/2
```

before this change, it was like this : 
```
- runit: leave stage: /etc/runit/1
                                  - runit: leave stage: /etc/runit/2
```