### PR TITLE
sv status: confusing output if log/supervise/ cannot be accessed

### DIFF
--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,3 +1,5 @@
+  * sv.c: status: if log/supervise/ can't be accessed, don't print confusing
+    additional line after warning message (introduced with 5fe1bc7).
   * etc/debian: rename to etc/sysv.
   * etc/freebsd: rename to etc/bsd.
   * etc/openbsd, etc/freebsd/getty-ttyv4, etc/debian/getty-tty5: remove;

--- a/src/sv.c
+++ b/src/sv.c
@@ -168,7 +168,7 @@ int status(char *unused) {
   }
   else {
     outs("; ");
-    if (svstatus_get()) { svstatus_print("log"); outs("\n"); }
+    if (svstatus_get() > 0) { svstatus_print("log"); outs("\n"); }
   }
   islog =0;
   flush("");

--- a/src/sv.dist
+++ b/src/sv.dist
@@ -1,7 +1,7 @@
 usage: sv [-v] [-w sec] command service ...
 
 100
-$Id: fe81761ea74cfdd6211cafc8b9e94f4870f42c43 $
+$Id: 833c7b3652fe7334d89dac90272d148c87fb7149 $
 usage: sv [-v] [-w sec] command service ...
 
 100


### PR DESCRIPTION
Don't print confusing additional line after warning message (#36); introduced with 5fe1bc7.