### PR TITLE
Add script for gammastep

### DIFF
--- a/doc/runscripts.html
+++ b/doc/runscripts.html
@@ -54,6 +54,7 @@ dutoit.</span></p>
 <a href="#fam">fam</a><br />
 <a href="#fcron">fcron</a><br />
 <a href="#fetchmail">fetchmail</a><br />
+<a href="#gammastep">gammastep</a><br />
 <a href="#gdm">gdm</a><br />
 <a href="#getty">getty</a><br />
 <a href="#gpm">gpm</a><br />
@@ -379,6 +380,18 @@ exec env FETCHMAILHOME=&quot;./pid&quot; \
     --nodetach \
     --daemon ${INTERVAL}</code></pre>
 <hr />
+<h3 id="a-gammastep-run-script"><span id="gammastep">A
+<code>gammastep</code> run script</span></h3>
+<p>(<em>Debian - Wayland</em>)</p>
+<pre><code>#!/bin/sh
+exec 2&gt;&amp;1
+export USER=&lt;your-username&gt;
+export XDG_RUNTIME_DIR=/tmp/runtime-$USER
+export WAYLAND_DISPLAY=wayland-1
+exec chpst -u $USER gammastep</code></pre>
+<hr />
+<p>You would need to either change the <code>USER</code> variable, or <a
+href="faq.html#user">run this service as user</a></p>
 <h3 id="a-gdm-run-script"><span id="gdm">A <code>gdm</code> run
 script</span></h3>
 <p>(<em>Debian woody</em>)</p>

--- a/md/runscripts.md
+++ b/md/runscripts.md
@@ -51,6 +51,7 @@ dutoit.]{.small}
 [fam](#fam)\
 [fcron](#fcron)\
 [fetchmail](#fetchmail)\
+[gammastep](#gammastep)\
 [gdm](#gdm)\
 [getty](#getty)\
 [gpm](#gpm)\
@@ -466,6 +467,23 @@ This service needs a [log service](faq.html#createlog) to be set up.
         --daemon ${INTERVAL}
 
 ---
+
+
+### [A `gammastep` run script]{#gammastep}
+
+(*Debian - Wayland*)
+
+    #!/bin/sh
+    exec 2>&1
+    export USER=<your-username>
+    export XDG_RUNTIME_DIR=/tmp/runtime-$USER
+    export WAYLAND_DISPLAY=wayland-1
+    exec chpst -u $USER gammastep
+
+---
+
+You would need to either change the `USER` variable, or
+[run this service as user](faq.html#user)
 
 ### [A `gdm` run script]{#gdm}
 


### PR DESCRIPTION
Hello!

First of all thank you for your job on runit <3

As a fresh user I started to tinker with runit scripts, idk if userspace init scripts like [gammastep](https://gitlab.com/chinstrap/gammastep)  are nice to have in docs, although as I have created one for me, I decided to open that PR.

In the meantime I would need to create few for `swayidle` and `pipewire` services, thus I can share these as well (of course if the maintainer/community would want it. 

Unfortunately they seem to be quite constrained with the distribution configuration.