### PR TITLE
Topic/runsvdir improvements

### DIFF
--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,4 +1,5 @@
-  * runsvdir.c: add selfpipe.
+  * runsvdir.c: add selfpipe; buffer and optimize readproctitle log; close
+    unused filedescriptor.
   * etc/debian: rename to etc/sysv.
   * etc/freebsd: rename to etc/bsd.
   * etc/openbsd, etc/freebsd/getty-ttyv4, etc/debian/getty-tty5: remove;

--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,3 +1,5 @@
+  * runsvdir.c: use inotify(7) (if available) to watch services directory;
+    remove overcautious delay; cleanup removed services more quickly.
   * Makefile, TARGETS: add test for inotify_init() system call.
   * hasinotify.h1, hasinotify.h2, tryinotify.c: new.
   * runsvdir.c: add selfpipe; buffer and optimize readproctitle log; close

--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,3 +1,4 @@
+  * runsvdir.c: add selfpipe.
   * etc/debian: rename to etc/sysv.
   * etc/freebsd: rename to etc/bsd.
   * etc/openbsd, etc/freebsd/getty-ttyv4, etc/debian/getty-tty5: remove;

--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,3 +1,5 @@
+  * Makefile, TARGETS: add test for inotify_init() system call.
+  * hasinotify.h1, hasinotify.h2, tryinotify.c: new.
   * runsvdir.c: add selfpipe; buffer and optimize readproctitle log; close
     unused filedescriptor.
   * etc/debian: rename to etc/sysv.

--- a/src/Makefile
+++ b/src/Makefile
@@ -185,6 +185,9 @@ fmt_ulong.o: compile fmt.h fmt_ulong.c
 hasflock.h: choose compile hasflock.h1 hasflock.h2 load tryflock.c
 	./choose cl tryflock hasflock.h1 hasflock.h2 > hasflock.h
 
+hasinotify.h: choose compile hasinotify.h1 hasinotify.h2 load tryinotify.c
+	./choose cl tryinotify hasinotify.h1 hasinotify.h2 > hasinotify.h
+
 hasmkffo.h: choose compile hasmkffo.h1 hasmkffo.h2 load trymkffo.c
 	./choose cl trymkffo hasmkffo.h1 hasmkffo.h2 > hasmkffo.h
 
@@ -328,7 +331,7 @@ strerr_sys.o: compile error.h strerr.h strerr_sys.c
 subgetopt.o: compile subgetopt.c subgetopt.h
 	./compile subgetopt.c
 
-sysdeps: compile direntry.h hasflock.h hasmkffo.h hassgact.h \
+sysdeps: compile direntry.h hasflock.h hasinotify.h hasmkffo.h hassgact.h \
 hassgprm.h hasunshare.h haswaitp.h iopause.h load select.h systype \
 uint64.h reboot_system.h socket.lib
 	rm -f sysdeps
@@ -344,6 +347,7 @@ uint64.h reboot_system.h socket.lib
 	grep sysdep hasflock.h >>sysdeps
 	grep sysdep reboot_system.h >>sysdeps
 	grep sysdep hasunshare.h >>sysdeps
+	grep sysdep hasinotify.h >>sysdeps
 	cat sysdeps
 
 systype: find-systype.sh trycpp.c x86cpuid.c

--- a/src/TARGETS
+++ b/src/TARGETS
@@ -53,6 +53,7 @@ fmt_uint.o
 fmt_uint0.o
 fmt_ulong.o
 hasflock.h
+hasinotify.h
 hasmkffo.h
 hassgact.h
 hassgprm.h

--- a/src/hasinotify.h1
+++ b/src/hasinotify.h1
@@ -1,0 +1,1 @@
+/* sysdep: -inotify */

--- a/src/hasinotify.h2
+++ b/src/hasinotify.h2
@@ -1,0 +1,2 @@
+/* sysdep: +inotify */
+#define HASINOTIFY 1

--- a/src/runsvdir.c
+++ b/src/runsvdir.c
@@ -1,3 +1,7 @@
+#include "hasinotify.h"
+#ifdef HASINOTIFY
+#include <sys/inotify.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -38,8 +42,20 @@ int selfpipe[2];
 char *rplog =0;
 int rploglen;
 int logpipe[2];
-char inbuf[256];
+#ifdef HASINOTIFY
+#define INBUFSIZE (sizeof(struct inotify_event) +NAME_MAX +1 > 256 ? \
+                   sizeof(struct inotify_event) +NAME_MAX +1 : 256)
+#define IOTIMEOUT 97
+#define IONUM 2
+iopause_fd io[3];
+int watch[2];
+#else
+#define INBUFSIZE 256
+#define IOTIMEOUT 5
+#define IONUM 1
 iopause_fd io[2];
+#endif
+char inbuf[INBUFSIZE];
 struct taia stamplog;
 int exitsoon =0;
 int pgrp =0;
@@ -139,7 +155,7 @@ void runsvdir() {
   for (i =0; i < svnum; i++) {
     if (! sv[i].isgone) continue;
     if (sv[i].pid) kill(sv[i].pid, SIGTERM);
-    sv[i] =sv[--svnum];
+    sv[i--] =sv[--svnum];
     check =1;
   }
 }
@@ -162,11 +178,28 @@ int setup_log() {
     warn3x("unable to set filedescriptor for log.", 0, 0);
     return(-1);
   }
-  io[1].fd =logpipe[0];
-  io[1].events =IOPAUSE_READ;
+  io[IONUM].fd =logpipe[0];
+  io[IONUM].events =IOPAUSE_READ;
   taia_now(&stamplog);
   return(1);
 }
+#ifdef HASINOTIFY
+unsigned int watch_inotify() {
+  int w;
+
+  if ((w =inotify_add_watch(io[1].fd, svdir, IN_DONT_FOLLOW|
+          IN_DELETE_SELF|IN_MOVE_SELF)) == -1)
+    return(0);
+  if (watch[0] != w) inotify_rm_watch(io[1].fd, watch[0]);
+  watch[0] =w;
+  if ((w =inotify_add_watch(io[1].fd, svdir,
+          IN_DELETE_SELF|IN_MOVE_SELF|IN_CREATE|IN_DELETE|IN_MOVE)) == -1)
+    return(0);
+  if (watch[1] != w) inotify_rm_watch(io[1].fd, watch[1]);
+  watch[1] =w;
+  return(1);
+}
+#endif
 
 int main(int argc, char **argv) {
   struct stat s;
@@ -209,7 +242,20 @@ int main(int argc, char **argv) {
   if ((curdir =open_read(".")) == -1) 
     fatal("unable to open current directory", 0);
   coe(curdir);
-
+#ifdef HASINOTIFY
+  if ((i =inotify_init()) == -1)
+    fatal("unable to initialize inotify instance", 0);
+  coe(i);
+  ndelay_on(i);
+  io[1].fd =i;
+  io[1].events =IOPAUSE_READ;
+  if ((watch[0] =inotify_add_watch(io[1].fd, svdir, IN_DONT_FOLLOW|
+          IN_DELETE_SELF|IN_MOVE_SELF)) == -1)
+    fatal("unable to add watch to inotify instance", 0);
+  if ((watch[1] =inotify_add_watch(io[1].fd, svdir,
+          IN_DELETE_SELF|IN_MOVE_SELF|IN_CREATE|IN_DELETE|IN_MOVE)) == -1)
+    fatal("unable to add watch to inotify instance", 0);
+#endif
   sig_block(sig_term);
   sig_catch(sig_term, s_term);
   sig_block(sig_hangup);
@@ -249,13 +295,15 @@ int main(int argc, char **argv) {
         if (check || \
             s.st_mtime != mtime || s.st_ino != ino || s.st_dev != dev) {
           /* svdir modified */
+#ifdef HASINOTIFY
+          if (!watch_inotify())
+            warn("unable to add watch to inotify instance", 0);
+#endif
           if (chdir(svdir) != -1) {
             mtime =s.st_mtime;
             dev =s.st_dev;
             ino =s.st_ino;
             check =0;
-            if (now.sec.x <= (4611686018427387914ULL +(uint64)mtime))
-              sleep(1);
             runsvdir();
             while (fchdir(curdir) == -1) {
               warn("unable to change directory, pausing", 0);
@@ -277,20 +325,26 @@ int main(int argc, char **argv) {
         taia_uint(&deadline, 900);
         taia_add(&stamplog, &now, &deadline);
       }
-    taia_uint(&deadline, check ? 1 : 5);
+    taia_uint(&deadline, check ? 1 : IOTIMEOUT);
     taia_add(&deadline, &now, &deadline);
     if (rplog && taia_less(&stamplog, &deadline)) deadline =stamplog;
 
     sig_unblock(sig_hangup);
     sig_unblock(sig_term);
     sig_unblock(sig_child);
-    iopause(io, 1 + (rplog ? 1 : 0), &deadline, &now);
+    iopause(io, IONUM + (rplog ? 1 : 0), &deadline, &now);
     sig_block(sig_child);
     sig_block(sig_term);
     sig_block(sig_hangup);
 
     if (io[0].revents) while (read(selfpipe[0], &ch, 1) == 1) {}
-    if (rplog && io[1].revents)
+#ifdef HASINOTIFY
+    if (io[1].revents) {
+      check =1;
+      while (read(io[1].fd, inbuf, sizeof(inbuf)) > 0) {}
+    }
+#endif
+    if (rplog && io[IONUM].revents)
       while ((i =read(logpipe[0], inbuf, 256)) > 0) {
         int j;
         if (i < rploglen)

--- a/src/runsvdir.c
+++ b/src/runsvdir.c
@@ -10,6 +10,7 @@
 #include "open.h"
 #include "pathexec.h"
 #include "fd.h"
+#include "byte.h"
 #include "str.h"
 #include "coe.h"
 #include "iopause.h"
@@ -37,6 +38,7 @@ int selfpipe[2];
 char *rplog =0;
 int rploglen;
 int logpipe[2];
+char inbuf[256];
 iopause_fd io[2];
 struct taia stamplog;
 int exitsoon =0;
@@ -147,6 +149,7 @@ int setup_log() {
     warn3x("log must have at least seven characters.", 0, 0);
     return(0);
   }
+  rplog +=5; rploglen -=5;
   if (pipe(logpipe) == -1) {
     warn3x("unable to create pipe for log.", 0, 0);
     return(-1);
@@ -155,7 +158,7 @@ int setup_log() {
   coe(logpipe[0]);
   ndelay_on(logpipe[0]);
   ndelay_on(logpipe[1]);
-  if (fd_copy(2, logpipe[1]) == -1) {
+  if (fd_move(2, logpipe[1]) == -1) {
     warn3x("unable to set filedescriptor for log.", 0, 0);
     return(-1);
   }
@@ -269,12 +272,14 @@ int main(int argc, char **argv) {
 
     if (rplog)
       if (taia_less(&now, &stamplog) == 0) {
-        write(logpipe[1], ".", 1);
+        for (i =1; i < rploglen; i++) rplog[i -1] =rplog[i];
+        rplog[rploglen -1] ='.';
         taia_uint(&deadline, 900);
         taia_add(&stamplog, &now, &deadline);
       }
     taia_uint(&deadline, check ? 1 : 5);
     taia_add(&deadline, &now, &deadline);
+    if (rplog && taia_less(&stamplog, &deadline)) deadline =stamplog;
 
     sig_unblock(sig_hangup);
     sig_unblock(sig_term);
@@ -286,12 +291,14 @@ int main(int argc, char **argv) {
 
     if (io[0].revents) while (read(selfpipe[0], &ch, 1) == 1) {}
     if (rplog && io[1].revents)
-      while (read(logpipe[0], &ch, 1) > 0)
-        if (ch) {
-          for (i =6; i < rploglen; i++)
-            rplog[i -1] =rplog[i];
-          rplog[rploglen -1] =ch;
-        }
+      while ((i =read(logpipe[0], inbuf, 256)) > 0) {
+        int j;
+        if (i < rploglen)
+          for (j =0; j < rploglen -i; ++j) rplog[j] =rplog[j +i];
+        j =i;
+        if (j > rploglen) j =rploglen;
+        byte_copy(rplog +rploglen -j, j, inbuf +i -j);
+      }
 
     switch(exitsoon) {
     case 1:

--- a/src/runsvdir.c
+++ b/src/runsvdir.c
@@ -33,10 +33,11 @@ struct {
 } sv[MAXSERVICES];
 int svnum =0;
 int check =1;
+int selfpipe[2];
 char *rplog =0;
 int rploglen;
 int logpipe[2];
-iopause_fd io[1];
+iopause_fd io[2];
 struct taia stamplog;
 int exitsoon =0;
 int pgrp =0;
@@ -50,9 +51,10 @@ void warn(char *m1, char *m2) {
 }
 void warn3x(char *m1, char *m2, char *m3) {
   strerr_warn6("runsvdir ", svdir, ": warning: ", m1, m2, m3, 0);
-} 
-void s_term(int unused) { exitsoon =1; }
-void s_hangup(int unused) { exitsoon =2; }
+}
+void s_term(int unused) { exitsoon =1; write(selfpipe[1], "", 1); }
+void s_hangup(int unused) { exitsoon =2; write(selfpipe[1], "", 1); }
+void s_child(int unused) { write(selfpipe[1], "", 1); }
 
 void runsv(int no, char *name) {
   int pid;
@@ -69,7 +71,11 @@ void runsv(int no, char *name) {
     prog[1] =name;
     prog[2] =0;
     sig_uncatch(sig_hangup);
+    sig_unblock(sig_hangup);
     sig_uncatch(sig_term);
+    sig_unblock(sig_term);
+    sig_uncatch(sig_child);
+    sig_unblock(sig_child);
     if (pgrp) setsid();
     pathexec_run(*prog, prog, (char* const*)environ);
     fatal("unable to start runsv ", name);
@@ -153,8 +159,8 @@ int setup_log() {
     warn3x("unable to set filedescriptor for log.", 0, 0);
     return(-1);
   }
-  io[0].fd =logpipe[0];
-  io[0].events =IOPAUSE_READ;
+  io[1].fd =logpipe[0];
+  io[1].events =IOPAUSE_READ;
   taia_now(&stamplog);
   return(1);
 }
@@ -180,10 +186,16 @@ int main(int argc, char **argv) {
     }
     if (! argv || ! *argv) usage();
   }
-
-  sig_catch(sig_term, s_term);
-  sig_catch(sig_hangup, s_hangup);
   svdir =*argv++;
+
+  if (pipe(selfpipe) == -1) fatal("unable to create selfpipe", 0);
+  coe(selfpipe[0]);
+  coe(selfpipe[1]);
+  ndelay_on(selfpipe[0]);
+  ndelay_on(selfpipe[1]);
+  io[0].fd =selfpipe[0];
+  io[0].events =IOPAUSE_READ;
+
   if (argv && *argv) {
     rplog =*argv;
     if (setup_log() != 1) {
@@ -195,6 +207,12 @@ int main(int argc, char **argv) {
     fatal("unable to open current directory", 0);
   coe(curdir);
 
+  sig_block(sig_term);
+  sig_catch(sig_term, s_term);
+  sig_block(sig_hangup);
+  sig_catch(sig_hangup, s_hangup);
+  sig_block(sig_child);
+  sig_catch(sig_child, s_child);
   taia_now(&stampcheck);
 
   for (;;) {
@@ -258,14 +276,16 @@ int main(int argc, char **argv) {
     taia_uint(&deadline, check ? 1 : 5);
     taia_add(&deadline, &now, &deadline);
 
-    sig_block(sig_child);
-    if (rplog)
-      iopause(io, 1, &deadline, &now);
-    else
-      iopause(0, 0, &deadline, &now);
+    sig_unblock(sig_hangup);
+    sig_unblock(sig_term);
     sig_unblock(sig_child);
+    iopause(io, 1 + (rplog ? 1 : 0), &deadline, &now);
+    sig_block(sig_child);
+    sig_block(sig_term);
+    sig_block(sig_hangup);
 
-    if (rplog && (io[0].revents | IOPAUSE_READ))
+    if (io[0].revents) while (read(selfpipe[0], &ch, 1) == 1) {}
+    if (rplog && io[1].revents)
       while (read(logpipe[0], &ch, 1) > 0)
         if (ch) {
           for (i =6; i < rploglen; i++)

--- a/src/runsvdir.c
+++ b/src/runsvdir.c
@@ -1,6 +1,7 @@
 #include "hasinotify.h"
 #ifdef HASINOTIFY
 #include <sys/inotify.h>
+#include <limits.h>
 #endif
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -47,15 +48,14 @@ int logpipe[2];
                    sizeof(struct inotify_event) +NAME_MAX +1 : 256)
 #define IOTIMEOUT 97
 #define IONUM 2
-iopause_fd io[3];
 int watch[2];
 #else
 #define INBUFSIZE 256
 #define IOTIMEOUT 5
 #define IONUM 1
-iopause_fd io[2];
 #endif
 char inbuf[INBUFSIZE];
+iopause_fd io[IONUM +1];
 struct taia stamplog;
 int exitsoon =0;
 int pgrp =0;

--- a/src/runsvdir.c
+++ b/src/runsvdir.c
@@ -46,12 +46,10 @@ int logpipe[2];
 #ifdef HASINOTIFY
 #define INBUFSIZE (sizeof(struct inotify_event) +NAME_MAX +1 > 256 ? \
                    sizeof(struct inotify_event) +NAME_MAX +1 : 256)
-#define IOTIMEOUT 97
 #define IONUM 2
 int watch[2];
 #else
 #define INBUFSIZE 256
-#define IOTIMEOUT 5
 #define IONUM 1
 #endif
 char inbuf[INBUFSIZE];
@@ -243,11 +241,10 @@ int main(int argc, char **argv) {
     fatal("unable to open current directory", 0);
   coe(curdir);
 #ifdef HASINOTIFY
-  if ((i =inotify_init()) == -1)
+  if ((io[1].fd =inotify_init()) == -1)
     fatal("unable to initialize inotify instance", 0);
-  coe(i);
-  ndelay_on(i);
-  io[1].fd =i;
+  coe(io[1].fd);
+  ndelay_on(io[1].fd);
   io[1].events =IOPAUSE_READ;
   if ((watch[0] =inotify_add_watch(io[1].fd, svdir, IN_DONT_FOLLOW|
           IN_DELETE_SELF|IN_MOVE_SELF)) == -1)
@@ -325,7 +322,7 @@ int main(int argc, char **argv) {
         taia_uint(&deadline, 900);
         taia_add(&stamplog, &now, &deadline);
       }
-    taia_uint(&deadline, check ? 1 : IOTIMEOUT);
+    taia_uint(&deadline, check ? 1 : 5);
     taia_add(&deadline, &now, &deadline);
     if (rplog && taia_less(&stamplog, &deadline)) deadline =stamplog;
 
@@ -349,8 +346,7 @@ int main(int argc, char **argv) {
         int j;
         if (i < rploglen)
           for (j =0; j < rploglen -i; ++j) rplog[j] =rplog[j +i];
-        j =i;
-        if (j > rploglen) j =rploglen;
+        j =(i > rploglen) ? rploglen : i;
         byte_copy(rplog +rploglen -j, j, inbuf +i -j);
       }
 

--- a/src/runsvdir.c
+++ b/src/runsvdir.c
@@ -47,7 +47,7 @@ int logpipe[2];
 #define INBUFSIZE (sizeof(struct inotify_event) +NAME_MAX +1 > 256 ? \
                    sizeof(struct inotify_event) +NAME_MAX +1 : 256)
 #define IONUM 2
-int watch[2];
+int watch[3];
 #else
 #define INBUFSIZE 256
 #define IONUM 1
@@ -195,6 +195,28 @@ unsigned int watch_inotify() {
     return(0);
   if (watch[1] != w) inotify_rm_watch(io[1].fd, watch[1]);
   watch[1] =w;
+  if (watch[0] != watch[1]) {
+    if ((w =readlink(svdir, inbuf, 256)) != -1) {
+      if (w < 256) {
+        inbuf[w] =0;
+        if (*inbuf == '/') {
+          if ((w =inotify_add_watch(io[1].fd, inbuf, IN_DONT_FOLLOW|
+                  IN_MASK_ADD|IN_DELETE_SELF|IN_MOVE_SELF)) == -1)
+            return(0);
+          if (watch[2] == w) return(1);
+          if (watch[2] != -1) inotify_rm_watch(io[1].fd, watch[2]);
+          watch[2] =(watch[1] == w) ? -1 : w;
+          return(1);
+        }
+      }
+      else
+        warn3x("unable to readlink ", svdir, ": name too long");
+    }
+    else
+      if (errno != EINVAL) warn("unable to readlink ", svdir);
+  }
+  if (watch[2] != -1) inotify_rm_watch(io[1].fd, watch[2]);
+  watch[2] =-1;
   return(1);
 }
 #endif
@@ -252,6 +274,7 @@ int main(int argc, char **argv) {
   if ((watch[1] =inotify_add_watch(io[1].fd, svdir,
           IN_DELETE_SELF|IN_MOVE_SELF|IN_CREATE|IN_DELETE|IN_MOVE)) == -1)
     fatal("unable to add watch to inotify instance", 0);
+  watch[2] =-1;
 #endif
   sig_block(sig_term);
   sig_catch(sig_term, s_term);

--- a/src/tryinotify.c
+++ b/src/tryinotify.c
@@ -1,0 +1,5 @@
+#include <sys/inotify.h>
+
+int main(void) {
+  return inotify_init();
+}


### PR DESCRIPTION
Add a selfpipe to runsvdir to synchronize signal handling with i/o, just as the runit and runsv programs do. This makes SIGCHLD handling faster.  Improve the readproctitle log and standard error processing with a buffer.

If the runsvdir program is built on a system that supports inotify(7), it now uses the inotify API to watch the services directory *dir*.