### PR TITLE
chpst.c: -2: dup() and coe() stderr, restore on failed exec

### DIFF
--- a/src/chpst.c
+++ b/src/chpst.c
@@ -29,6 +29,8 @@
 #include "open.h"
 #include "openreadclose.h"
 #include "direntry.h"
+#include "coe.h"
+#include "fd.h"
 
 #define USAGE_MAIN " [-vVPFI012] [-u user[:group]] [-U user[:group]] [-b argv0] [-e dir] [-/ root] [-C pwd] [-n nice] [-l|-L lock] [-m n] [-d n] [-o n] [-p n] [-f n] [-c n] [-t n] prog"
 #define FATAL "chpst: fatal: "
@@ -64,6 +66,7 @@ unsigned int pgrp =0;
 unsigned int nostdin =0;
 unsigned int nostdout =0;
 unsigned int nostderr =0;
+int savederr =-1;
 unsigned int newpids =0;
 long limitd =-2;
 long limits =-2;
@@ -427,14 +430,23 @@ int main(int argc, char **argv) {
   if (env_user) euidgid(env_user, 1);
   if (set_user) suidgid(set_user, 1);
   if (lock) slock(lock, lockdelay, 0);
-  if (nostdin) if (close(0) == -1) fatal("unable to close stdin");
+  if (nostderr) {
+    if ((savederr = dup(2)) == -1) fatal("unable to save stderr");
+    coe(savederr);
+    if (close(2) == -1) fatal("unable to close stderr");
+  }
   if (nostdout) if (close(1) == -1) fatal("unable to close stdout");
-  if (nostderr) if (close(2) == -1) fatal("unable to close stderr");
+  if (nostdin) if (close(0) == -1) fatal("unable to close stdin");
   slimit();
 
   progname =*argv;
   if (argv0) *argv =argv0;
   pathexec_env_run(progname, argv);
+  if (savederr >= 0) {
+    int e = errno;
+    fd_move(2, savederr);
+    errno = e;
+  }
   fatal2("unable to run", *argv);
   return(0);
 }

--- a/src/chpst.check
+++ b/src/chpst.check
@@ -34,3 +34,7 @@ echo $?
 
 chpst -012 true
 echo $?
+
+chpst -2 ./ENOENT.err 2>/dev/null
+echo $?
+chpst -012 ./ENOENT.err 2>&1 |sed -e 's/chpst: fatal: unable to run: .\/ENOENT\.err:.*/ENOENT/'

--- a/src/chpst.dist
+++ b/src/chpst.dist
@@ -1,7 +1,7 @@
 usage: chpst [-vVPFI012] [-u user[:group]] [-U user[:group]] [-b argv0] [-e dir] [-/ root] [-C pwd] [-n nice] [-l|-L lock] [-m n] [-d n] [-o n] [-p n] [-f n] [-c n] [-t n] prog
 
 100
-$Id: effe51d5b2f4f54c3aace29eee3cee7ece90c4a5 $
+$Id: 0cd84183ab1248bb25616a82f988d4633b3b4c0f $
 usage: chpst [-vVPFI012] [-u user[:group]] [-U user[:group]] [-b argv0] [-e dir] [-/ root] [-C pwd] [-n nice] [-l|-L lock] [-m n] [-d n] [-o n] [-p n] [-f n] [-c n] [-t n] prog
 
 100
@@ -11,3 +11,5 @@ test=1
 0
 0
 0
+111
+ENOENT


### PR DESCRIPTION
Addresses #41 

These changes modify the behavior of `-2` to save stderr and set it close-on-exec, with restoring it for diagnostics if chpst's ultimate execve fails.  stderr is handled before stdout and stdin so the dup() won't assume those descriptors.   Small test cases are added.

The successful case on Linux looks like this:
```
root@f3f193560f43:/tmp/build/compile# ./chpst -2 -l /tmp/foo sh -c 'ls -l /proc/$$/fd/'
total 0
lrwx------ 1 root root 64 Jun 18 17:46 0 -> /dev/pts/0
lrwx------ 1 root root 64 Jun 18 17:46 1 -> /dev/pts/0
l-wx------ 1 root root 64 Jun 18 17:46 3 -> /tmp/foo
```