### PR TITLE
fix chpst.check: silence alarm probe shell stderr

### DIFF
--- a/src/chpst.check
+++ b/src/chpst.check
@@ -37,15 +37,15 @@ echo $?
 
 chpst -2 ./ENOENT.err 2>/dev/null
 echo $?
-chpst -012 ./ENOENT.err 2>&1 |sed -e 's/chpst: fatal: unable to run: .\/ENOENT\.err:.*/ENOENT/'
+chpst -012 ./ENOENT.err 2>&1
 
 chpst -N012 true
 echo $?
 chpst -N2 ./ENOENT.err 2>/dev/null
 echo $?
-chpst -N012 ./ENOENT.err 2>&1 |sed -e 's/chpst: fatal: unable to run: .\/ENOENT\.err:.*/ENOENT/'
+chpst -N012 ./ENOENT.err 2>&1
 
-chpst -A 2 /bin/sh -c 'trap "x=1" ALRM; unset -v x; sleep 10 & wait $!; test -n "$x" && echo ALRM'
+chpst -A 2 /bin/sh -c 'trap "echo ALRM" ALRM; sleep 5 & wait $!'
 
-chpst -A 2 chpst -A 0 /bin/sh -c 'trap "echo ALRM" ALRM; sleep 2 & wait $!'
+chpst -A 1 chpst -A 0 /bin/sh -c 'trap "echo ALRM" ALRM; sleep 2 & wait $!'
 echo $?

--- a/src/chpst.check
+++ b/src/chpst.check
@@ -45,11 +45,11 @@ chpst -N2 ./ENOENT.err 2>/dev/null
 echo $?
 chpst -N012 ./ENOENT.err 2>&1 |sed -e 's/chpst: fatal: unable to run: .\/ENOENT\.err:.*/ENOENT/'
 
-/bin/sh -c 'kill -s ALRM $$' 2>/dev/null
+/bin/sh -c 'kill -s ALRM $$ 2>/dev/null' 2>/dev/null
 EC_ALRM=$?
 
 # POSIX allows sleep(1) to exit 0 on ALRM, so we wait for it
-chpst -A 2 /bin/sh -c 'sleep 10 & wait $!' 2>/dev/null
+chpst -A 2 /bin/sh -c 'sleep 10 & wait $! 2>/dev/null' 2>/dev/null
 test $? -eq $EC_ALRM && echo ALRM
 
 chpst -A 2 chpst -A 0 /bin/sh -c 'sleep 2 & wait $!'

--- a/src/chpst.check
+++ b/src/chpst.check
@@ -45,9 +45,12 @@ chpst -N2 ./ENOENT.err 2>/dev/null
 echo $?
 chpst -N012 ./ENOENT.err 2>&1 |sed -e 's/chpst: fatal: unable to run: .\/ENOENT\.err:.*/ENOENT/'
 
-{ /bin/sh -c 'kill -s ALRM $$' >/dev/null 2>&1; EC_ALRM=$?; } 2>/dev/null
-{ /bin/sh -c 'chpst -A 2 sleep 10' >/dev/null 2>&1; EC_CHPST=$?; } 2>/dev/null
-test "$EC_CHPST" -eq "$EC_ALRM" && echo ALRM
+/bin/sh -c 'kill -s ALRM $$' 2>/dev/null
+EC_ALRM=$?
 
-chpst -A 2 chpst -A 0 sleep 2
+# POSIX allows sleep(1) to exit 0 on ALRM, so we wait for it
+chpst -A 2 /bin/sh -c 'sleep 10 & wait $!' 2>/dev/null
+test $? -eq $EC_ALRM && echo ALRM
+
+chpst -A 2 chpst -A 0 /bin/sh -c 'sleep 2 & wait $!'
 echo $?

--- a/src/chpst.check
+++ b/src/chpst.check
@@ -45,12 +45,7 @@ chpst -N2 ./ENOENT.err 2>/dev/null
 echo $?
 chpst -N012 ./ENOENT.err 2>&1 |sed -e 's/chpst: fatal: unable to run: .\/ENOENT\.err:.*/ENOENT/'
 
-/bin/sh -c 'kill -s ALRM $$ 2>/dev/null' 2>/dev/null
-EC_ALRM=$?
+chpst -A 2 /bin/sh -c 'trap "x=1" ALRM; unset -v x; sleep 10 & wait $!; test -n "$x" && echo ALRM'
 
-# POSIX allows sleep(1) to exit 0 on ALRM, so we wait for it
-chpst -A 2 /bin/sh -c 'sleep 10 & wait $! 2>/dev/null' 2>/dev/null
-test $? -eq $EC_ALRM && echo ALRM
-
-chpst -A 2 chpst -A 0 /bin/sh -c 'sleep 2 & wait $!'
+chpst -A 2 chpst -A 0 /bin/sh -c 'trap "echo ALRM" ALRM; sleep 2 & wait $!'
 echo $?

--- a/src/chpst.check
+++ b/src/chpst.check
@@ -45,11 +45,9 @@ chpst -N2 ./ENOENT.err 2>/dev/null
 echo $?
 chpst -N012 ./ENOENT.err 2>&1 |sed -e 's/chpst: fatal: unable to run: .\/ENOENT\.err:.*/ENOENT/'
 
-/bin/sh -c 'kill -s ALRM $$' 2>/dev/null
-EC_ALRM=$?
-
-/bin/sh -c 'chpst -A 2 sleep 10' 2>/dev/null
-test $? -eq $EC_ALRM && echo ALRM
+{ /bin/sh -c 'kill -s ALRM $$' >/dev/null 2>&1; EC_ALRM=$?; } 2>/dev/null
+{ /bin/sh -c 'chpst -A 2 sleep 10' >/dev/null 2>&1; EC_CHPST=$?; } 2>/dev/null
+test "$EC_CHPST" -eq "$EC_ALRM" && echo ALRM
 
 chpst -A 2 chpst -A 0 sleep 2
 echo $?

--- a/src/chpst.dist
+++ b/src/chpst.dist
@@ -12,9 +12,9 @@ test=1
 0
 0
 111
-ENOENT
+chpst: fatal: unable to run: ./ENOENT.err: file does not exist
 0
 111
-ENOENT
+chpst: fatal: unable to run: ./ENOENT.err: file does not exist
 ALRM
 0


### PR DESCRIPTION
Repair tests, by devnull'ing stderr output on chpst alarm tests, which output was confounding the checks during non-Linux builds.  Process behavior was correct, but expected test output was not.

Some of the shells would emit "Alarm clock..." and similar warnings to stderr during the newly introduced `chpst -A` tests.  `check-local` captured this, causing the unit tests to fail.