### PR TITLE
src: buffer size PATH_MAX instead of 256 if RUNSV_USE_SYSLIMITS is de…

### DIFF
--- a/package/CHANGES
+++ b/package/CHANGES
@@ -1,3 +1,5 @@
+  * runit.h, runsv.c, runsvdir.c, Makefile: buffer size PATH_MAX instead of
+    256 if RUNSV_USE_SYSLIMITS is defined.
   * chpst.c, chpst.check, man/chpst.8: add new option -A: alarm(2) support
     (github/pilcrow).
   * sv.c: improve warning if ./log exists but not ./log/supervise/ok (thx

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,16 +30,16 @@ svlogd: load svlogd.o pmatch.o fmt_ptime.o unix.a byte.a time.a socket.lib
 chpst: load chpst.o uidgid.o unix.a byte.a
 	./load chpst uidgid.o unix.a byte.a
 
-runit.o: compile sysdeps runit.c
+runit.o: compile sysdeps runit.c runit.h
 	./compile runit.c
 
-runit-init.o: compile runit-init.c
+runit-init.o: compile runit-init.c runit.h
 	./compile runit-init.c
 
-runsv.o: compile sysdeps runsv.c
+runsv.o: compile sysdeps runsv.c runit.h
 	./compile runsv.c
 
-runsvdir.o: compile sysdeps runsvdir.c
+runsvdir.o: compile sysdeps runsvdir.c runit.h
 	./compile runsvdir.c
 
 sv.o: compile sysdeps sv.c

--- a/src/runit.h
+++ b/src/runit.h
@@ -3,3 +3,13 @@
 #define REBOOT "/etc/runit/reboot"
 #define NOSYNC "/etc/runit/nosync"
 #define CTRLALTDEL "/etc/runit/ctrlaltdel"
+
+#ifdef RUNSV_USE_SYSLIMITS
+#include <limits.h>
+#ifndef PATH_MAX
+#define PATH_MAX 256
+#endif
+#define BUFSIZE (PATH_MAX > 256 ? PATH_MAX : 256)
+#else
+#define BUFSIZE 256
+#endif

--- a/src/runsv.c
+++ b/src/runsv.c
@@ -1,3 +1,4 @@
+#include "runit.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -392,7 +393,7 @@ int main(int argc, char **argv) {
   struct stat s;
   int fd;
   int r;
-  char buf[256];
+  char buf[BUFSIZE];
 
   progname =argv[0];
   if (! argv[1] || argv[2]) usage();
@@ -443,8 +444,8 @@ int main(int argc, char **argv) {
   }
 
   if (mkdir("supervise", 0700) == -1) {
-    if ((r =readlink("supervise", buf, 256)) != -1) {
-      if (r == 256)
+    if ((r =readlink("supervise", buf, BUFSIZE)) != -1) {
+      if (r == BUFSIZE)
         fatalx("unable to readlink ./supervise: ", "name too long");
       buf[r] =0;
       mkdir(buf, 0700);
@@ -460,8 +461,8 @@ int main(int argc, char **argv) {
   coe(svd[0].fdlock);
   if (haslog) {
     if (mkdir("log/supervise", 0700) == -1) {
-      if ((r =readlink("log/supervise", buf, 256)) != -1) {
-        if (r == 256)
+      if ((r =readlink("log/supervise", buf, BUFSIZE)) != -1) {
+        if (r == BUFSIZE)
           fatalx("unable to readlink ./log/supervise: ", "name too long");
         buf[r] =0;
         if ((fd =open_read(".")) == -1)

--- a/src/runsvdir.c
+++ b/src/runsvdir.c
@@ -1,3 +1,4 @@
+#include "runit.h"
 #include "hasinotify.h"
 #ifdef HASINOTIFY
 #include <sys/inotify.h>
@@ -44,12 +45,12 @@ char *rplog =0;
 int rploglen;
 int logpipe[2];
 #ifdef HASINOTIFY
-#define INBUFSIZE (sizeof(struct inotify_event) +NAME_MAX +1 > 256 ? \
-                   sizeof(struct inotify_event) +NAME_MAX +1 : 256)
+#define INBUFSIZE (sizeof(struct inotify_event) +NAME_MAX +1 > BUFSIZE ? \
+                   sizeof(struct inotify_event) +NAME_MAX +1 : BUFSIZE)
 #define IONUM 2
 int watch[3];
 #else
-#define INBUFSIZE 256
+#define INBUFSIZE BUFSIZE
 #define IONUM 1
 #endif
 char inbuf[INBUFSIZE];
@@ -196,8 +197,8 @@ unsigned int watch_inotify() {
   if (watch[1] != w) inotify_rm_watch(io[1].fd, watch[1]);
   watch[1] =w;
   if (watch[0] != watch[1]) {
-    if ((w =readlink(svdir, inbuf, 256)) != -1) {
-      if (w < 256) {
+    if ((w =readlink(svdir, inbuf, BUFSIZE)) != -1) {
+      if (w < BUFSIZE) {
         inbuf[w] =0;
         if (*inbuf == '/') {
           if ((w =inotify_add_watch(io[1].fd, inbuf, IN_DONT_FOLLOW|
@@ -365,7 +366,7 @@ int main(int argc, char **argv) {
     }
 #endif
     if (rplog && io[IONUM].revents)
-      while ((i =read(logpipe[0], inbuf, 256)) > 0) {
+      while ((i =read(logpipe[0], inbuf, BUFSIZE)) > 0) {
         int j;
         if (i < rploglen)
           for (j =0; j < rploglen -i; ++j) rplog[j] =rplog[j +i];


### PR DESCRIPTION
…fined

The runsv and runsvdir programs use a 256 char buffer for readlink(2) and other operations. If RUNSV_USE_SYSLIMITS is defined when building the programs, the system's constant limit PATH_MAX is used instead.