### PR TITLE
runit: shut down on SIGPWR if /etc/runit/pwrfail exists

### DIFF
--- a/doc/runit.8.html
+++ b/doc/runit.8.html
@@ -57,11 +57,9 @@ system.</p>
 keyboard request is triggered.</p>
 <p>If <strong>runit</strong> receives a PWR signal and the file
 <em>/etc/runit/pwrfail</em> exists and has the execute by owner
-permission set, <strong>runit</strong> sets the execute by owner
-permission on <em>/etc/runit/stopit</em>; then it runs
-<em>/etc/runit/pwrfail</em>, waits for it to terminate, and sends itself
-a CONT signal. On platforms where PWR is not defined, USR2 is used
-instead.</p>
+permission set, <strong>runit</strong> runs <em>/etc/runit/pwrfail</em>,
+waits for it to terminate, and then sends itself a CONT signal. On
+platforms where PWR is not defined, USR2 is used instead.</p>
 <h3 id="see-also">SEE ALSO</h3>
 <p>runit-init(8), runsvdir(8), runsvchdir(8), sv(8), runsv(8), chpst(8),
 svlogd(8)</p>

--- a/doc/runit.8.html
+++ b/doc/runit.8.html
@@ -55,6 +55,13 @@ permission set, <strong>runit</strong> is told to shutdown the
 system.</p>
 <p>If <strong>runit</strong> receives an INT signal, a ctrl-alt-del
 keyboard request is triggered.</p>
+<p>If <strong>runit</strong> receives a PWR signal and the file
+<em>/etc/runit/pwrfail</em> exists and has the execute by owner
+permission set, <strong>runit</strong> sets the execute by owner
+permission on <em>/etc/runit/stopit</em>; then it runs
+<em>/etc/runit/pwrfail</em>, waits for it to terminate, and sends itself
+a CONT signal. On platforms where PWR is not defined, USR2 is used
+instead.</p>
 <h3 id="see-also">SEE ALSO</h3>
 <p>runit-init(8), runsvdir(8), runsvchdir(8), sv(8), runsv(8), chpst(8),
 svlogd(8)</p>

--- a/man/runit.8
+++ b/man/runit.8
@@ -54,9 +54,8 @@ request is triggered.
 .PP
 If \f[B]runit\f[R] receives a PWR signal and the file
 \f[I]/etc/runit/pwrfail\f[R] exists and has the execute by owner
-permission set, \f[B]runit\f[R] sets the execute by owner permission on
-\f[I]/etc/runit/stopit\f[R]; then it runs \f[I]/etc/runit/pwrfail\f[R],
-waits for it to terminate, and sends itself a CONT signal.
+permission set, \f[B]runit\f[R] runs \f[I]/etc/runit/pwrfail\f[R], waits
+for it to terminate, and then sends itself a CONT signal.
 On platforms where PWR is not defined, USR2 is used instead.
 .SH SEE ALSO
 runit\-init(8), runsvdir(8), runsvchdir(8), sv(8), runsv(8), chpst(8),

--- a/man/runit.8
+++ b/man/runit.8
@@ -51,6 +51,13 @@ permission set, \f[B]runit\f[R] is told to shutdown the system.
 .PP
 If \f[B]runit\f[R] receives an INT signal, a ctrl\-alt\-del keyboard
 request is triggered.
+.PP
+If \f[B]runit\f[R] receives a PWR signal and the file
+\f[I]/etc/runit/pwrfail\f[R] exists and has the execute by owner
+permission set, \f[B]runit\f[R] sets the execute by owner permission on
+\f[I]/etc/runit/stopit\f[R]; then it runs \f[I]/etc/runit/pwrfail\f[R],
+waits for it to terminate, and sends itself a CONT signal.
+On platforms where PWR is not defined, USR2 is used instead.
 .SH SEE ALSO
 runit\-init(8), runsvdir(8), runsvchdir(8), sv(8), runsv(8), chpst(8),
 svlogd(8)

--- a/md/runit.8.md
+++ b/md/runit.8.md
@@ -58,10 +58,10 @@ If **runit** receives an INT signal, a ctrl-alt-del keyboard request is
 triggered.
 
 If **runit** receives a PWR signal and the file */etc/runit/pwrfail*
-exists and has the execute by owner permission set, **runit** sets the
-execute by owner permission on */etc/runit/stopit*; then it runs
-*/etc/runit/pwrfail*, waits for it to terminate, and sends itself a CONT
-signal. On platforms where PWR is not defined, USR2 is used instead.
+exists and has the execute by owner permission set, **runit** runs
+*/etc/runit/pwrfail*, waits for it to terminate, and then sends itself a
+CONT signal. On platforms where PWR is not defined, USR2 is used
+instead.
 
 # SEE ALSO
 

--- a/md/runit.8.md
+++ b/md/runit.8.md
@@ -57,6 +57,12 @@ shutdown the system.
 If **runit** receives an INT signal, a ctrl-alt-del keyboard request is
 triggered.
 
+If **runit** receives a PWR signal and the file */etc/runit/pwrfail*
+exists and has the execute by owner permission set, **runit** sets the
+execute by owner permission on */etc/runit/stopit*; then it runs
+*/etc/runit/pwrfail*, waits for it to terminate, and sends itself a CONT
+signal. On platforms where PWR is not defined, USR2 is used instead.
+
 # SEE ALSO
 
 runit-init(8), runsvdir(8), runsvchdir(8), sv(8), runsv(8), chpst(8),

--- a/src/runit.c
+++ b/src/runit.c
@@ -30,6 +30,7 @@ const char * const stage[3] ={
 int selfpipe[2];
 int sigc =0;
 int sigi =0;
+int sigp =0;
 
 void sig_cont_handler (int unused) {
   sigc++;
@@ -37,6 +38,10 @@ void sig_cont_handler (int unused) {
 }
 void sig_int_handler (int unused) {
   sigi++;
+  write(selfpipe[1], "", 1);
+}
+void sig_pwr_handler (int unused) {
+  sigp++;
   write(selfpipe[1], "", 1);
 }
 void sig_child_handler (int unused) { write(selfpipe[1], "", 1); }
@@ -71,6 +76,8 @@ int main (int argc, const char * const *argv, char * const *envp) {
   sig_block(sig_hangup);
   sig_block(sig_int);
   sig_catch(sig_int, sig_int_handler);
+  sig_block(sig_pwr);
+  sig_catch(sig_pwr, sig_pwr_handler);
   sig_block(sig_pipe);
   sig_block(sig_term);
 
@@ -135,6 +142,8 @@ int main (int argc, const char * const *argv, char * const *envp) {
       sig_unblock(sig_int);
       sig_uncatch(sig_int);
       sig_unblock(sig_pipe);
+      sig_unblock(sig_pwr);
+      sig_uncatch(sig_pwr);
       sig_unblock(sig_term);
             
       strerr_warn3(INFO, "enter stage: ", stage[st], 0);
@@ -150,6 +159,7 @@ int main (int argc, const char * const *argv, char * const *envp) {
       sig_unblock(sig_child);
       sig_unblock(sig_cont);
       sig_unblock(sig_int);
+      sig_unblock(sig_pwr);
 #ifdef IOPAUSE_POLL
       poll(&x, 1, 14000);
 #else
@@ -161,6 +171,7 @@ int main (int argc, const char * const *argv, char * const *envp) {
       sig_block(sig_cont);
       sig_block(sig_child);
       sig_block(sig_int);
+      sig_block(sig_pwr);
       
       while (read(selfpipe[0], &ch, 1) == 1) {}
       while ((child =wait_nohang(&wstat)) > 0)
@@ -211,7 +222,7 @@ int main (int argc, const char * const *argv, char * const *envp) {
       }
 
       /* sig? */
-      if (!sigc  && !sigi) {
+      if (!sigc && !sigi && !sigp) {
 #ifdef DEBUG
         strerr_warn2(WARNING, "poll: ", &strerr_sys);
 #endif
@@ -219,7 +230,7 @@ int main (int argc, const char * const *argv, char * const *envp) {
       }
       if (st != 1) {
         strerr_warn2(WARNING, "signals only work in stage 2.", 0);
-        sigc =sigi =0;
+        sigc =sigi =sigp =0;
         continue;
       }
       if (sigi && (stat(CTRLALTDEL, &s) != -1) && (s.st_mode & S_IXUSR)) {
@@ -242,6 +253,29 @@ int main (int argc, const char * const *argv, char * const *envp) {
           strerr_warn3(WARNING, "child crashed: ", CTRLALTDEL, 0);
         strerr_warn3(INFO, "leave stage: ", prog[0], 0);
         sigi =0;
+        sigc++;
+      }
+      if (sigp && (stat(PWRFAIL, &s) != -1) && (s.st_mode & S_IXUSR)) {
+        strerr_warn2(INFO, "powerfail event...", 0);
+        prog[0] =PWRFAIL; prog[1] =0;
+        if (stat(STOPIT, &s) != -1) chmod(STOPIT, 0100);
+        while ((pid2 =fork()) == -1) {
+          strerr_warn4(FATAL, "unable to fork for \"", PWRFAIL,
+                       "\" pausing: ", &strerr_sys);
+          sleep(5);
+        }
+        if (!pid2) {
+          /* child */
+          strerr_warn3(INFO, "enter stage: ", prog[0], 0);
+          execve(*prog, (char *const *) prog, envp);
+          strerr_die4sys(0, FATAL, "unable to start child: ", prog[0], ": ");
+        }
+        if (wait_pid(&wstat, pid2) == -1)
+          strerr_warn2(FATAL, "wait_pid: ", &strerr_sys);
+        if (wait_crashed(wstat))
+          strerr_warn3(WARNING, "child crashed: ", PWRFAIL, 0);
+        strerr_warn3(INFO, "leave stage: ", prog[0], 0);
+        sigp =0;
         sigc++;
       }
       if (sigc && (stat(STOPIT, &s) != -1) && (s.st_mode & S_IXUSR)) {
@@ -286,7 +320,7 @@ int main (int argc, const char * const *argv, char * const *envp) {
         /* enter stage 3 */
         break;
       }
-      sigc =sigi =0;
+      sigc =sigi =sigp =0;
 #ifdef DEBUG
       strerr_warn2(WARNING, "no request.", 0);
 #endif

--- a/src/runit.c
+++ b/src/runit.c
@@ -258,7 +258,6 @@ int main (int argc, const char * const *argv, char * const *envp) {
       if (sigp && (stat(PWRFAIL, &s) != -1) && (s.st_mode & S_IXUSR)) {
         strerr_warn2(INFO, "powerfail event...", 0);
         prog[0] =PWRFAIL; prog[1] =0;
-        if (stat(STOPIT, &s) != -1) chmod(STOPIT, 0100);
         while ((pid2 =fork()) == -1) {
           strerr_warn4(FATAL, "unable to fork for \"", PWRFAIL,
                        "\" pausing: ", &strerr_sys);

--- a/src/runit.h
+++ b/src/runit.h
@@ -3,6 +3,7 @@
 #define REBOOT "/etc/runit/reboot"
 #define NOSYNC "/etc/runit/nosync"
 #define CTRLALTDEL "/etc/runit/ctrlaltdel"
+#define PWRFAIL "/etc/runit/pwrfail"
 
 #ifdef RUNSV_USE_SYSLIMITS
 #include <limits.h>

--- a/src/sig.c
+++ b/src/sig.c
@@ -4,7 +4,7 @@
 #include "sig.h"
 
 #ifndef SIGPWR
-#define SIGPWR SIGUSR2 /* as in sysvinit */
+#define SIGPWR SIGUSR2 /* as in sysvinit's init.c */
 #endif
 
 int sig_alarm = SIGALRM;

--- a/src/sig.c
+++ b/src/sig.c
@@ -3,12 +3,17 @@
 #include <signal.h>
 #include "sig.h"
 
+#ifndef SIGPWR
+#define SIGPWR SIGUSR2 /* as in sysvinit */
+#endif
+
 int sig_alarm = SIGALRM;
 int sig_child = SIGCHLD;
 int sig_cont = SIGCONT;
 int sig_hangup = SIGHUP;
 int sig_int = SIGINT;
 int sig_pipe = SIGPIPE;
+int sig_pwr = SIGPWR;
 int sig_term = SIGTERM;
 
 void (*sig_defaulthandler)(int) = SIG_DFL;

--- a/src/sig.h
+++ b/src/sig.h
@@ -9,6 +9,7 @@ extern int sig_cont;
 extern int sig_hangup;
 extern int sig_int;
 extern int sig_pipe;
+extern int sig_pwr;
 extern int sig_term;
 
 extern void (*sig_defaulthandler)(int);


### PR DESCRIPTION
This is a port of Debian's runit [patch to support SIGPWR](https://sources.debian.org/src/runit/2.3.1-4/debian/patches/0013-Shutdown-when-runit-init-receices-SIGPWR.patch/) with a couple of fixes.

Container frameworks (e.g. Incus, LXC) use SIGPWR to poweroff containers. runit ignores these, so `incus stop` hangs until timeout, e.g.

```sh
incus launch images:voidlinux/current runit-repro
incus stop runit-repro --timeout 10    # hangs
```

The feature is opt-in (requires `/etc/runit/pwrfail` one-liner that exits 0), so it can be rolled out incrementally or only to stock void container images.

Fixes atop the 2019 Debian patch (powered by Claude Fable):

- on fork() failure the pwrfail handler retries in a loop like the existing ctrlaltdel handler, instead of falling through to wait_pid(&wstat, -1), which would reap an arbitrary child.
- stage children unblock and uncatch SIGPWR before execve, matching the treatment of the other caught signals; Debian's patch leaves SIGPWR (SIGUSR2 on platforms without it) blocked in the inherited signal mask of every process on the system.